### PR TITLE
Front end changes (12 Nov)

### DIFF
--- a/components/faculty/accomplishments/academic-accomplishment-form.js
+++ b/components/faculty/accomplishments/academic-accomplishment-form.js
@@ -1,0 +1,56 @@
+import React from 'react'
+
+class AcadAccomplishmentForm extends React.Component{
+	constructor(){
+		super()
+	}
+	clone(){
+		alert('add')
+	}
+	remove(){
+		alert('remove')
+	}
+	render(){
+		return(
+			<form>
+                    <hr />
+                    <div className = "form-row">
+                        <div className = "col-auto">
+                            <button type = "button" className = "btn btn-primary" id = "AddAccomplishment" onClick = {() => this.clone()}> Add Accomplishment </button>
+                        </div>
+                        <div className = "col-auto">
+                            <button type = "button" className = "btn btn-danger" id = "RemoveAccomplishment" onClick = {() => this.remove()}> Remove a Row </button>
+                        </div>
+                    </div>
+                    <br />
+                    <div className = "form-row">
+                        <div className = "form-group col-md-2">
+                            <label htmlFor = "AcademicAccomplishment[]"> Accomplishment </label>
+                            <input className = "form-control" type = "text" name = "AcademicAccomplishment[]" placeholder = "Input accomplishment" />
+                        </div>
+			<div className = "form-group col-md-4">
+                            <label htmlFor = "AcademicAccomplishmentDescription[]"> Description </label>
+                            <input className = "form-control" type = "text" name = "AcademicAccomplishmentDescription[]" placeholder = "Input description" />
+                        </div>
+                        <div className = "form-group col-md-2">
+                            <label htmlFor = "AcademicAccomplishmentDate[]"> Date </label>
+                            <input type = "date" className = "form-control" name = "AcademicAccomplishmentDate[]" />
+                        </div>
+                        <div className = "form-group col-md-2">
+                            <label htmlFor = "AcademicAccomplishmentProof[]"> Proof </label>
+                            <input type = "file" className = "form-control-file" name = "AcademicAccomplishmentProof[]" />
+                        </div>
+                    </div>
+                    <div id = "AcademicAccomplishment">
+                        {/* <!-- Duplicate fields will appear here --> */}
+                    </div>
+                    <br />
+                    <button type = "submit" className = "btn btn-primary"> Submit </button>
+                    <hr />
+                    
+                </form>
+		)
+	}
+}
+
+export default AcadAccomplishmentForm

--- a/components/faculty/accomplishments/academic-accomplishment.js
+++ b/components/faculty/accomplishments/academic-accomplishment.js
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import AcadAccomplishmentForm from './academic-accomplishment-form'
 
 function AcademicAccomplishment(){
 	return(
@@ -32,43 +33,7 @@ function AcademicAccomplishment(){
             </div>
 
             <div>
-                <form>
-                    <hr />
-                    <div className = "form-row">
-                        <div className = "col-auto">
-                            <button type = "button" className = "btn btn-primary" id = "AddAccomplishment"> Add Accomplishment </button>
-                        </div>
-                        <div className = "col-auto">
-                            <button type = "button" className = "btn btn-danger" id = "RemoveAccomplishment"> Remove a Row </button>
-                        </div>
-                    </div>
-                    <br />
-                    <div className = "form-row">
-                        <div className = "form-group col-md-2">
-                            <label htmlFor = "AcademicAccomplishment[]"> Accomplishment </label>
-                            <input className = "form-control" type = "text" name = "AcademicAccomplishment[]" placeholder = "Input accomplishment" />
-                        </div>
-			<div className = "form-group col-md-4">
-                            <label htmlFor = "AcademicAccomplishmentDescription[]"> Description </label>
-                            <input className = "form-control" type = "text" name = "AcademicAccomplishmentDescription[]" placeholder = "Input description" />
-                        </div>
-                        <div className = "form-group col-md-2">
-                            <label htmlFor = "AcademicAccomplishmentDate[]"> Date </label>
-                            <input type = "date" className = "form-control" name = "AcademicAccomplishmentDate[]" />
-                        </div>
-                        <div className = "form-group col-md-2">
-                            <label htmlFor = "AcademicAccomplishmentProof[]"> Proof </label>
-                            <input type = "file" className = "form-control-file" name = "AcademicAccomplishmentProof[]" />
-                        </div>
-                    </div>
-                    <div id = "AcademicAccomplishment">
-                        {/* <!-- Duplicate fields will appear here --> */}
-                    </div>
-                    <br />
-                    <button type = "submit" className = "btn btn-primary"> Submit </button>
-                    <hr />
-                    
-                </form>
+                <AcadAccomplishmentForm />
             </div>   
 
             <div className="modal fade" id="ongoing" tabindex="-1" role="dialog" aria-labelledby="ongoingLabel" aria-hidden="true">

--- a/components/faculty/accomplishments/licensure-exam-form.js
+++ b/components/faculty/accomplishments/licensure-exam-form.js
@@ -1,0 +1,52 @@
+import React from 'react'
+
+class LicensureExamForm extends React.Component{
+	constructor(){
+		super()
+	}
+	clone(){
+		alert('add')
+	}
+	remove(){
+		alert('remove')
+	}
+	render(){
+		return(
+			<form>
+                    <hr />
+                    <div className = "form-row">
+                        <div className = "col-auto">
+                            <button type = "button" className = "btn btn-primary" id = "AddAccomplishment" onClick = {() => this.clone()}> Add Licensure Exam </button>
+                        </div>
+                        <div className = "col-auto">
+                            <button type = "button" className = "btn btn-danger" id = "RemoveAccomplishment" onClick = {() => this.remove()}> Remove a Row </button>
+                        </div>
+                    </div>
+                    <br />
+                    <div className = "form-row">
+                        <div className = "form-group col-md-2">
+                            <label htmlFor = "LicensureExam[]"> Licensure Exam </label>
+                            <input className = "form-control" type = "text" name = "LicensureExam[]" placeholder = "Input licensure exam" />
+                        </div>
+			<div className = "form-group col-md-2">
+                            <label htmlFor = "LicensureExamDate[]"> Date </label>
+                            <input type = "date" className = "form-control" name = "LicensureExamDate[]" />
+                        </div>
+			<div className = "form-group col-md-2">
+                            <label htmlFor = "LicensureExamRank[]"> Rank </label>
+                            <input className = "form-control" type = "text" name = "LicensureExamRank[]" placeholder = "Input rank" />
+                        </div>
+                    </div>
+                    <div id = "LicensureExam">
+                        {/* <!-- Duplicate fields will appear here --> */}
+                    </div>
+                    <br />
+                    <button type = "submit" className = "btn btn-primary"> Submit </button>
+                    <hr />
+                    
+                </form>
+		)
+	}
+}
+
+export default LicensureExamForm

--- a/components/faculty/accomplishments/licensure-exam.js
+++ b/components/faculty/accomplishments/licensure-exam.js
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import LicensureExamForm from './licensure-exam-form'
 
 function LicensureExam(){
 	return(
@@ -26,39 +27,7 @@ function LicensureExam(){
             </div>
 
             <div>
-                <form>
-                    <hr />
-                    <div className = "form-row">
-                        <div className = "col-auto">
-                            <button type = "button" className = "btn btn-primary" id = "AddAccomplishment"> Add Licensure Exam </button>
-                        </div>
-                        <div className = "col-auto">
-                            <button type = "button" className = "btn btn-danger" id = "RemoveAccomplishment"> Remove a Row </button>
-                        </div>
-                    </div>
-                    <br />
-                    <div className = "form-row">
-                        <div className = "form-group col-md-2">
-                            <label htmlFor = "LicensureExam[]"> Licensure Exam </label>
-                            <input className = "form-control" type = "text" name = "LicensureExam[]" placeholder = "Input licensure exam" />
-                        </div>
-			<div className = "form-group col-md-2">
-                            <label htmlFor = "LicensureExamDate[]"> Date </label>
-                            <input type = "date" className = "form-control" name = "LicensureExamDate[]" />
-                        </div>
-			<div className = "form-group col-md-2">
-                            <label htmlFor = "LicensureExamRank[]"> Rank </label>
-                            <input className = "form-control" type = "text" name = "LicensureExamRank[]" placeholder = "Input rank" />
-                        </div>
-                    </div>
-                    <div id = "LicensureExam">
-                        {/* <!-- Duplicate fields will appear here --> */}
-                    </div>
-                    <br />
-                    <button type = "submit" className = "btn btn-primary"> Submit </button>
-                    <hr />
-                    
-                </form>
+                <LicensureExamForm />
             </div>   
 
             </div>

--- a/components/faculty/accomplishments/public-service-accomplishment-form.js
+++ b/components/faculty/accomplishments/public-service-accomplishment-form.js
@@ -1,0 +1,56 @@
+import React from 'react'
+
+class PublicServiceAccomplishmentForm extends React.Component{
+	constructor(){
+		super()
+	}
+	clone(){
+		alert('add')
+	}
+	remove(){
+		alert('remove')
+	}
+	render(){
+		return(
+			<form>
+                    <hr />
+                    <div className = "form-row">
+                        <div className = "col-auto">
+                            <button type = "button" className = "btn btn-primary" id = "AddAccomplishment" onClick = {() => this.clone()}> Add Accomplishment </button>
+                        </div>
+                        <div className = "col-auto">
+                            <button type = "button" className = "btn btn-danger" id = "RemoveAccomplishment" onClick = {() => this.remove()}> Remove a Row </button>
+                        </div>
+                    </div>
+                    <br />
+                    <div className = "form-row">
+                        <div className = "form-group col-md-2">
+                            <label htmlFor = "PublicServiceAccomplishment[]"> Accomplishment </label>
+                            <input className = "form-control" type = "text" name = "PublicServiceAccomplishment[]" placeholder = "Input accomplishment" />
+                        </div>
+			<div className = "form-group col-md-4">
+                            <label htmlFor = "PublicServiceAccomplishmentDescription[]"> Description </label>
+                            <input className = "form-control" type = "text" name = "PublicServiceAccomplishmentDescription[]" placeholder = "Input description" />
+                        </div>
+                        <div className = "form-group col-md-2">
+                            <label htmlFor = "PublicServiceAccomplishmentDate[]"> Date </label>
+                            <input type = "date" className = "form-control" name = "PublicServiceAccomplishmentDate[]" />
+                        </div>
+                        <div className = "form-group col-md-2">
+                            <label htmlFor = "PublicServiceAccomplishmentProof[]"> Proof </label>
+                            <input type = "file" className = "form-control-file" name = "PublicServiceAccomplishmentProof[]" />
+                        </div>
+                    </div>
+                    <div id = "PublicServiceAccomplishment">
+                        {/* <!-- Duplicate fields will appear here --> */}
+                    </div>
+                    <br />
+                    <button type = "submit" className = "btn btn-primary"> Submit </button>
+                    <hr />
+                    
+                </form>
+		)
+	}
+}
+
+export default PublicServiceAccomplishmentForm

--- a/components/faculty/accomplishments/public-service-accomplishment.js
+++ b/components/faculty/accomplishments/public-service-accomplishment.js
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import PublicServiceAccomplishmentForm from './public-service-accomplishment-form'
 
 function PublicServiceAccomplishment(){
 	return(
@@ -32,43 +33,7 @@ function PublicServiceAccomplishment(){
             </div>
 
             <div>
-                <form>
-                    <hr />
-                    <div className = "form-row">
-                        <div className = "col-auto">
-                            <button type = "button" className = "btn btn-primary" id = "AddAccomplishment"> Add Accomplishment </button>
-                        </div>
-                        <div className = "col-auto">
-                            <button type = "button" className = "btn btn-danger" id = "RemoveAccomplishment"> Remove a Row </button>
-                        </div>
-                    </div>
-                    <br />
-                    <div className = "form-row">
-                        <div className = "form-group col-md-2">
-                            <label htmlFor = "PublicServiceAccomplishment[]"> Accomplishment </label>
-                            <input className = "form-control" type = "text" name = "PublicServiceAccomplishment[]" placeholder = "Input accomplishment" />
-                        </div>
-			<div className = "form-group col-md-4">
-                            <label htmlFor = "PublicServiceAccomplishmentDescription[]"> Description </label>
-                            <input className = "form-control" type = "text" name = "PublicServiceAccomplishmentDescription[]" placeholder = "Input description" />
-                        </div>
-                        <div className = "form-group col-md-2">
-                            <label htmlFor = "PublicServiceAccomplishmentDate[]"> Date </label>
-                            <input type = "date" className = "form-control" name = "PublicServiceAccomplishmentDate[]" />
-                        </div>
-                        <div className = "form-group col-md-2">
-                            <label htmlFor = "PublicServiceAccomplishmentProof[]"> Proof </label>
-                            <input type = "file" className = "form-control-file" name = "PublicServiceAccomplishmentProof[]" />
-                        </div>
-                    </div>
-                    <div id = "PublicServiceAccomplishment">
-                        {/* <!-- Duplicate fields will appear here --> */}
-                    </div>
-                    <br />
-                    <button type = "submit" className = "btn btn-primary"> Submit </button>
-                    <hr />
-                    
-                </form>
+                <PublicServiceAccomplishmentForm />
             </div>   
 
             </div>

--- a/components/faculty/accomplishments/publication-form.js
+++ b/components/faculty/accomplishments/publication-form.js
@@ -1,0 +1,53 @@
+import React from 'react'
+
+class PublicationForm extends React.Component{
+	constructor(){
+		super()
+	}
+	clone(){
+		alert('add')
+	}
+	remove(){
+		alert('remove')
+	}
+	render(){
+		return(
+			<form>
+		<h5> Publications </h5>
+		<hr />
+		<div className = "form-row">
+			<div className = "col-auto">
+				<button type = "button" className = "btn btn-primary" id = "AddPublication" onClick = {() => this.clone()}> Add Publication </button>
+			</div>
+			<div className = "col-auto">
+				<button type = "button" className = "btn btn-danger" id = "RemovePublication" onClick = {() => this.remove()}> Remove a Row </button>
+			</div>
+		</div>
+		<br />
+		<div className = "form-row">
+			<div className = "form-group col-md-2">
+				<label htmlFor = "Publication[]"> Publication </label>
+				<input className = "form-control" type = "text" name = "Publication[]" placeholder = "Input publication name" />
+			</div>
+			<div className = "form-group col-md-4">
+				<label htmlFor = "PublicationAuthor[]"> Author/s </label>
+				<input className = "form-control" type = "text" name = "PublicationAuthor[]" placeholder = "Input publication authors" />
+			</div>
+			<div className = "form-group col-md-2">
+				<label htmlFor = "PublishDate[]"> Date Published </label>
+				<input type = "date" className = "form-control" name = "PublishDate[]" />
+			</div>
+
+		</div>
+		<div id = "Publication">
+		</div>
+		<br />
+		<button type = "submit" className = "btn btn-primary"> Submit </button>
+		<hr />
+		
+	</form>
+		)
+	}
+}
+
+export default PublicationForm

--- a/components/faculty/accomplishments/publication.js
+++ b/components/faculty/accomplishments/publication.js
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import PublicationForm from './publication-form'
 
 function Publication(){
 	return(
@@ -28,43 +29,10 @@ function Publication(){
 			</tr>
 		</tbody>
 	</table>	
-</div>
-<div>
-	<form>
-		<h5> Publications </h5>
-		<hr />
-		<div className = "form-row">
-			<div className = "col-auto">
-				<button type = "button" className = "btn btn-primary" id = "AddPublication"> Add Publication </button>
-			</div>
-			<div className = "col-auto">
-				<button type = "button" className = "btn btn-danger" id = "RemovePublication"> Remove a Row </button>
-			</div>
-		</div>
-		<br />
-		<div className = "form-row">
-			<div className = "form-group col-md-2">
-				<label htmlFor = "Publication[]"> Publication </label>
-				<input className = "form-control" type = "text" name = "Publication[]" placeholder = "Input publication name" />
-			</div>
-			<div className = "form-group col-md-4">
-				<label htmlFor = "PublicationAuthor[]"> Author/s </label>
-				<input className = "form-control" type = "text" name = "PublicationAuthor[]" placeholder = "Input publication authors" />
-			</div>
-			<div className = "form-group col-md-2">
-				<label htmlFor = "PublishDate[]"> Date Published </label>
-				<input type = "date" className = "form-control" name = "PublishDate[]" />
-			</div>
-
-		</div>
-		<div id = "Publication">
-		</div>
-		<br />
-		<button type = "submit" className = "btn btn-primary"> Submit </button>
-		<hr />
-		
-	</form>
-</div>
+	</div>
+	<div>
+		<PublicationForm />
+	</div>
 		</div>
 	)
 }

--- a/components/faculty/basic-info/education-form.js
+++ b/components/faculty/basic-info/education-form.js
@@ -1,0 +1,65 @@
+import React from 'react'
+
+class EducationForm extends React.Component{
+	constructor(){
+		super()
+	}
+
+	clone(){
+		alert('add')
+	}
+	remove(){
+		alert('remove')
+	}
+	render(){
+		return(
+		<form>
+                    <hr />
+                    <div className = "form-row">
+                        <div className = "col-auto">
+                            <button type = "button" className = "btn btn-primary" id = "AddEducationalHistory" onClick = {() => this.clone()}> Add Educational History </button>
+                        </div>
+                        <div className = "col-auto">
+                            <button type = "button" className = "btn btn-danger" id = "RemoveEducationalHistory" onClick = {() => this.remove()}> Remove a Row </button>
+                        </div>
+                    </div>
+                    <br />
+                    <div className = "form-row">
+                        <div className = "form-group col-md-2">
+                            <label htmlFor = "SchoolEducationalHistory[]"> School/Institution </label>
+                            <input className = "form-control" type = "text" name = "SchoolEducationalHistory[]" placeholder = "Input school" />
+                        </div>
+                        <div className = "form-group col-md-2">
+                            <label htmlFor = "DegreeEducationalHistory[]"> Degree/Certification </label>
+                            <input className = "form-control" type = "text" name = "DegreeEducationalHistory[]" placeholder = "Input degree" />
+                        </div>
+                        <div className = "form-group col-md-2">
+                            <label htmlFor = "MajorEducationalHistory[]"> Major/Specialization </label>
+                            <input className = "form-control" type = "text" name = "MajorEducationalHistory[]" placeholder = "Input major" />
+                        </div>
+                        <div className = "form-group col-md-2">
+                            <label htmlFor = "StartDateEducationalHistory[]"> Start Date </label>
+                            <input type = "date" className = "form-control" name = "StartDateEducationalHistory[]" />
+                        </div>
+                        <div className = "form-group col-md-2">
+                            <label htmlFor = "EndDateEducationalHistory[]"> End Date </label>
+                            <input type = "date" className = "form-control" name = "EndDateEducationalHistory[]" />
+                        </div>
+                        <div className = "form-group col-md-2">
+                            <label htmlFor = "ProofEducationalHistory[]"> Proof </label>
+                            <input type = "file" className = "form-control-file" name = "ProofEducationalHistory[]" />
+                        </div>
+                    </div>
+                    <div id = "EducationalHistory">
+                        {/* Duplicate fields will appear here */}
+                    </div>
+                    <br />
+                    <button type = "submit" className = "btn btn-primary"> Submit </button>
+                    <hr />
+                   
+                </form>
+	)
+	}
+}
+
+export default EducationForm

--- a/components/faculty/basic-info/education.js
+++ b/components/faculty/basic-info/education.js
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import EducationForm from './education-form'
 
 function Education() {
     return (
@@ -18,9 +19,9 @@ function Education() {
                         <tr>
                             <td>University of the Philippines Diliman</td>
                             <td>Doctor of Philosophy in Computer Science</td>
-                            <td></td>
+                            <td>None</td>
                             <td>2020-01-26</td>
-                            <td></td>
+                            <td>Present</td>
                             <td></td>
                             <td><a className="btn btn-info" data-toggle="modal" data-target="#ongoing">Ongoing</a></td>
                         </tr>
@@ -47,52 +48,7 @@ function Education() {
             </div>
 
             <div>
-                <form>
-                    <hr />
-                    <div className = "form-row">
-                        <div className = "col-auto">
-                            <button type = "button" className = "btn btn-primary" id = "AddEducationalHistory"> Add Educational History </button>
-                        </div>
-                        <div className = "col-auto">
-                            <button type = "button" className = "btn btn-danger" id = "RemoveEducationalHistory"> Remove a Row </button>
-                        </div>
-                    </div>
-                    <br />
-                    <div className = "form-row">
-                        <div className = "form-group col-md-2">
-                            <label htmlFor = "SchoolEducationalHistory[]"> School/Institution </label>
-                            <input className = "form-control" type = "text" name = "SchoolEducationalHistory[]" placeholder = "Input school" />
-                        </div>
-                        <div className = "form-group col-md-2">
-                            <label htmlFor = "DegreeEducationalHistory[]"> Degree/Certification </label>
-                            <input className = "form-control" type = "text" name = "DegreeEducationalHistory[]" placeholder = "Input degree" />
-                        </div>
-                        <div className = "form-group col-md-2">
-                            <label htmlFor = "MajorEducationalHistory[]"> Major/Specialization </label>
-                            <input className = "form-control" type = "text" name = "MajorEducationalHistory[]" placeholder = "Input major" />
-                        </div>
-                        <div className = "form-group col-md-2">
-                            <label htmlFor = "StartDateEducationalHistory[]"> Start Date </label>
-                            <input type = "date" className = "form-control" name = "StartDateEducationalHistory[]" />
-                        </div>
-                        <div className = "form-group col-md-2">
-                            <label htmlFor = "EndDateEducationalHistory[]"> End Date </label>
-                            <input type = "date" className = "form-control" name = "EndDateEducationalHistory[]" />
-                        </div>
-                        <div className = "form-group col-md-2">
-                            <label htmlFor = "ProofEducationalHistory[]"> Proof </label>
-                            <input type = "file" className = "form-control-file" name = "ProofEducationalHistory[]" />
-                        </div>
-                    </div>
-                    <div id = "EducationalHistory">
-                        {/* <!-- Duplicate fields will appear here --> */}
-                    </div>
-                    <br />
-                    <button type = "submit" className = "btn btn-primary"> Submit </button>
-                    <hr />
-                    
-                    {/* <!-- End of Educational History --> */}
-                </form>
+                <EducationForm />
             </div>   
 
             <div className="modal fade" id="ongoing" tabindex="-1" role="dialog" aria-labelledby="ongoingLabel" aria-hidden="true">
@@ -171,22 +127,26 @@ function Education() {
             </div>
         
         </div>
-        // $(document).ready(function(){
-        //     // HTML for duplicate educational history fields
-        //     var AdditionalFieldEducationalHistory = '<hr class = "duplicate"><div class = "form-row"><div class = "form-group col-md-2"><label for = "SchoolEducationalHistory[]"> School/Institution </label><input class = "form-control" type = "text" name = "SchoolEducationalHistory[]" placeholder = "Input school" ></div><div class = "form-group col-md-2"><label for = "DegreeEducationalHistory[]"> Degree/Certification </label><input class = "form-control" type = "text" name = "DegreeEducationalHistory[]" placeholder = "Input degree" ></div><div class = "form-group col-md-2"><label for = "MajorEducationalHistory[]"> Major/Specialization </label><input class = "form-control" type = "text" name = "MajorEducationalHistory[]" placeholder = "Input major"></div><div class = "form-group col-md-2"><label for = "StartDateEducationalHistory[]"> Start Date </label><input type = "date" class = "form-control" name = "StartDateEducationalHistory[]" ></div><div class = "form-group col-md-2"><label for = "EndDateEducationalHistory[]"> End Date </label><input type = "date" class = "form-control" name = "EndDateEducationalHistory[]"></div></div>';
 
-        //     // Appends new educational history fields
-        //     $("#AddEducationalHistory").click(function(){
+	
+       // $(document).ready(function(){
+            // HTML for duplicate educational history fields
+         //   var AdditionalFieldEducationalHistory = '<hr class = "duplicate"><div class = "form-row"><div class = "form-group col-md-2"><label for = "SchoolEducationalHistory[]"> School/Institution </label><input class = "form-control" type = "text" name = "SchoolEducationalHistory[]" placeholder = "Input school" ></div><div class = "form-group col-md-2"><label for = "DegreeEducationalHistory[]"> Degree/Certification </label><input class = "form-control" type = "text" name = "DegreeEducationalHistory[]" placeholder = "Input degree" ></div><div class = "form-group col-md-2"><label for = "MajorEducationalHistory[]"> Major/Specialization </label><input class = "form-control" type = "text" name = "MajorEducationalHistory[]" placeholder = "Input major"></div><div class = "form-group col-md-2"><label for = "StartDateEducationalHistory[]"> Start Date </label><input type = "date" class = "form-control" name = "StartDateEducationalHistory[]" ></div><div class = "form-group col-md-2"><label for = "EndDateEducationalHistory[]"> End Date </label><input type = "date" class = "form-control" name = "EndDateEducationalHistory[]"></div></div>';
+
+             // Appends new educational history fields
+         //    $("#AddEducationalHistory").click(function(){
         //         $("#EducationalHistory").append(AdditionalFieldEducationalHistory);
-        //     });
+        //    });
 
-        //     // Removes last row of duplicate educational history fields
-        //     $("#RemoveEducationalHistory").click(function(){
+            // Removes last row of duplicate educational history fields
+         //    $("#RemoveEducationalHistory").click(function(){
         //         $("#EducationalHistory").children("div").last().remove();
         //         $("#EducationalHistory").children("hr").last().remove();
-        //     });
+       //     });
 
-        // });
+      //   });
+	
+	
     )
   }
   

--- a/components/faculty/basic-info/employment-history.js
+++ b/components/faculty/basic-info/employment-history.js
@@ -13,7 +13,7 @@ function EmploymentHistory(){
 			<tr>
 				<td>Professor 2</td>
 				<td>2020-01-26</td>
-				<td></td>
+				<td>Present</td>
 			</tr>
 			<tr>
 				<td>Professor 1</td>

--- a/components/faculty/basic-info/work-exp-form.js
+++ b/components/faculty/basic-info/work-exp-form.js
@@ -1,0 +1,65 @@
+import React from 'react';
+
+class WorkExpForm extends React.Component{
+	constructor(){
+		super()
+	}
+
+	clone(){
+		alert('add')
+	}
+	remove(){
+		alert('remove')
+	}
+
+	render(){
+		return(
+			<form>
+			<hr />
+			<div className = "form-row">
+				<div className = "col-auto">
+					<button type = "button" className = "btn btn-primary" id = "AddWorkExperience" onClick = {() => this.clone()}> Add Work Experience </button>
+				</div>
+				<div className = "col-auto">
+					<button type = "button" className = "btn btn-danger" id = "RemoveWorkExperience" onClick = {() => this.remove()}> Remove a Row </button>
+				</div>
+			</div>
+			<br />
+			<div className = "form-row">
+				<div className = "form-group col-md-3">
+					<label htmlFor = "EmployerWorkExperience[]"> Employer </label>
+					<input className = "form-control" type = "text" name = "EmployerWorkExperience[]" placeholder = "Input name of employer" />
+				</div>
+				<div className = "form-group col-md-3">
+					<label htmlFor = "PositionWorkExperience[]"> Title/Position </label>
+					<input className = "form-control" type = "text" name = "PositionWorkExperience[]" placeholder = "Input position" />
+				</div>
+			</div>
+			<div className = "form-row">
+				<div className = "form-group col-md-3">
+					<label htmlFor = "StartDateWorkExperience[]"> Start Date </label>
+					<input type = "date" className = "form-control" name = "StartDateWorkExperience[]" />
+				</div>
+				<div className = "form-group col-md-3">
+					<label htmlFor = "EndDateWorkExperience[]"> End Date </label>
+					<input type = "date" className = "form-control" name = "EndDateWorkExperience[]" />
+				</div>
+			</div>
+			<div className = "form-group">
+				<label htmlFor = "DescriptionWorkExperience[]"> Description </label>
+				<input className = "form-control col-md-6" type = "text" name = "DescriptionWorkExperience[]" placeholder = "Add Description" />
+			</div>
+			<div id = "WorkExperience">
+				{/* duplicate forms here */}
+			</div>
+			<br />
+			<button type = "submit" className = "btn btn-primary"> Submit </button>
+			<hr />
+		
+			</form>
+		)
+	}
+
+}
+
+export default WorkExpForm;

--- a/components/faculty/basic-info/work-experience.js
+++ b/components/faculty/basic-info/work-experience.js
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import WorkExpForm from './work-exp-form'
 
 function WorkExperience(){
 	return(
@@ -16,68 +17,27 @@ function WorkExperience(){
 					<td>Professor 2</td>
 					<td>University of the Philippines Diliman</td>
 					<td>2020-01-26</td>
-					<td></td>
-					<td></td>
+					<td>Present</td>
+					<td>CMSC 127 professor</td>
 				</tr>
 				<tr>
 					<td>Professor 1</td>
 					<td>University of the Philippines Diliman</td>
 					<td>2017-05-26</td>
 					<td>2020-01-25</td>
-					<td></td>
+					<td>Stat 130 professor</td>
 				</tr>
 				<tr>
 					<td>Instructor 1</td>
 					<td>University of the Philippines Los Banos</td>
 					<td>2010-09-06</td>
 					<td>2017-05-25</td>
-					<td></td>
+					<td>Math 121.1 Professor</td>
 				</tr>
 			</tbody>
 		</table>
 <div>
-	<form>
-		<hr />
-		<div className = "form-row">
-			<div className = "col-auto">
-				<button type = "button" className = "btn btn-primary" id = "AddWorkExperience"> Add Work Experience </button>
-			</div>
-			<div className = "col-auto">
-				<button type = "button" className = "btn btn-danger" id = "RemoveWorkExperience"> Remove a Row </button>
-			</div>
-		</div>
-		<br />
-		<div className = "form-row">
-			<div className = "form-group col-md-3">
-				<label htmlFor = "EmployerWorkExperience[]"> Employer </label>
-				<input className = "form-control" type = "text" name = "EmployerWorkExperience[]" placeholder = "Input name of employer" />
-			</div>
-			<div className = "form-group col-md-3">
-				<label htmlFor = "PositionWorkExperience[]"> Title/Position </label>
-				<input className = "form-control" type = "text" name = "PositionWorkExperience[]" placeholder = "Input position" />
-			</div>
-		</div>
-		<div className = "form-row">
-			<div className = "form-group col-md-3">
-					<label htmlFor = "StartDateWorkExperience[]"> Start Date </label>
-					<input type = "date" className = "form-control" name = "StartDateWorkExperience[]" />
-				</div>
-				<div className = "form-group col-md-3">
-					<label htmlFor = "EndDateWorkExperience[]"> End Date </label>
-					<input type = "date" className = "form-control" name = "EndDateWorkExperience[]" />
-			</div>
-		</div>
-		<div className = "form-group">
-			<label htmlFor = "DescriptionWorkExperience[]"> Description </label>
-			<input className = "form-control col-md-6" type = "text" name = "DescriptionWorkExperience[]" placeholder = "Add Description" />
-		</div>
-		<div id = "WorkExperience">
-		</div>
-		<br />
-		<button type = "submit" className = "btn btn-primary"> Submit </button>
-		<hr />
-		
-	</form>
+	<WorkExpForm />
 </div>
 
 </div>

--- a/components/sidebar.js
+++ b/components/sidebar.js
@@ -5,27 +5,30 @@ function Sidebar() {
             <div className="col-2">
                 <div className="list-group">
 			<a className = "list-group-item list-group-item-action list-group-item-secondary" data-toggle = "collapse" href = "#faculty"> Faculty </a>
-			<div id = "faculty" className = "collapse">
+			<div id = "faculty" className = "collapse show">
                     <Link href="/faculty"><a className = "list-group-item list-group-item-action list-group-item-success">Dashboard</a></Link>
                     <Link href="/faculty/basic-info"><a className = "list-group-item list-group-item-action list-group-item-success">Basic Information</a></Link>
                     <Link href="/faculty/accomplishment"><a className = "list-group-item list-group-item-action list-group-item-success">Accomplishment</a></Link>
                     <Link href="/faculty/class"><a className = "list-group-item list-group-item-action list-group-item-success">Class</a></Link>
-                    <Link href="/faculty/evaluation"><a className = "list-group-item list-group-item-action list-group-item-success">Evaluation</a></Link>
+                    <Link href="/faculty/evaluation"><a className = "list-group-item list-group-item-action list-group-item-success ">Evaluation</a></Link>
 			</div>
                 </div>
                 <div className="list-group">
-                    <Link href="/student"><a className = "list-group-item list-group-item-action list-group-item-success">Student</a></Link>
+                    <Link href="/student"><a className = "list-group-item list-group-item-action list-group-item-secondary">Student</a></Link>
                 </div>
                 <div className="list-group">
-                    <Link href="/alumni"><a className = "list-group-item list-group-item-action list-group-item-success">Alumni</a></Link>
+                    <Link href="/alumni"><a className = "list-group-item list-group-item-action list-group-item-secondary">Alumni</a></Link>
                 </div>
                 <div className="list-group">
-                    <Link href="/department-activities"><a className = "list-group-item list-group-item-action list-group-item-success">Department Activities</a></Link>
+                    <Link href="/department-activities"><a className = "list-group-item list-group-item-action list-group-item-secondary">Department Activities</a></Link>
                 </div>
 
 		<style jsx>{`
 			.col-2 {
   				background-color: #017823; 
+			}
+			.list-group-item-success{
+				text-indent:20%;
 			}
 		`}</style>
             </div>           


### PR DESCRIPTION
Changelog:
[components/sidebar.js]
- accordion menu has been adjusted to be expanded by default, and sub-menu item text now has indentations
[components/faculty/basic-info]
- minor edits to the table display for work-experience, employment-history, and education
- new files added (education-form, work-exp-form)
- HTML for the forms in education and work-experience removed (they now instead call the above files to render the forms for their respective pages)
[components/faculty/accomplishments]
- new files added (academic-accomplishment-form, licensure-exam-form, public-service-accomplishment-form, publication-form)
- HTML for the forms in all the accomplishment pages removed (they now instead call the above files to render the forms for their respective pages)
